### PR TITLE
Fix warnings

### DIFF
--- a/lib/curtail.ex
+++ b/lib/curtail.ex
@@ -110,7 +110,8 @@ defmodule Curtail do
           _ ->
             chars_remaining - String.length(token)
         end
-      true -> #noop
+      true ->
+        nil #noop
     end
 
     do_truncate(rest, tags, opts, chars_remaining, acc)

--- a/lib/curtail.ex
+++ b/lib/curtail.ex
@@ -130,7 +130,7 @@ defmodule Curtail do
     tokens_with_omission = tokens
                             |> List.first
                             |> String.rstrip
-                            |> Kernel.<> omission
+                            |> Kernel.<>(omission)
 
     List.replace_at(tokens, 0, tokens_with_omission)
   end

--- a/test/curtail/options_test.exs
+++ b/test/curtail/options_test.exs
@@ -1,7 +1,6 @@
-defmodule Curtail.HtmlTagTest do
+defmodule Curtail.OptionsTest do
   use ExUnit.Case
 
-  import Curtail.Options
   alias Curtail.Options
 
   test "creating options" do


### PR DESCRIPTION
I was getting a lot of noise when using curtail in Phoenix so I've cleaned up the warnings
