### PR TITLE
Remove Elixir 1.3 compilation warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,8 +20,8 @@ defmodule Curtail.Mixfile do
   end
 
   defp deps do
-    [{:earmark, "~> 0.1", only: :dev},
-      {:ex_doc, "~> 0.6", only: :dev}]
+    [{:earmark, "~> 1.0", only: :dev},
+      {:ex_doc, "~> 0.13", only: :dev}]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"earmark": {:hex, :earmark, "0.1.12"},
-  "ex_doc": {:hex, :ex_doc, "0.6.1"}}
+%{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}


### PR DESCRIPTION
This removes what is I believe the only remaining instance of this warning in curtail:

```
warning: the variable "rest" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:
```

It also updates the dev-only dependencies on `earmark` and `ex_doc`, as the older versions produce a number of the same sort of warning. 
