### PR TITLE
Update for Elixir 1.19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,24 @@
 language: elixir
 
 elixir:
-  - 1.10.4
+  - 1.16.1
+  - 1.17.3-otp-27
+  - 1.18.4-otp-28
 otp_release:
-  - 21.2
-  - 22.3
-  - 23.0
+  - 25.3.2.21
+  - 27.3.4.3
+  - 28.1
 
 dist: bionic
 
 jobs:
   include:
-    - elixir: 1.4.4
-      otp_release: 19.1
+    - elixir: 1.16.1
+      otp_release: 25.3.2.21
       dist: trusty
-    - elixir: 1.4.4
-      otp_release: 19.2
+    - elixir: 1.17.3-otp-27
+      otp_release: 27.3.4.3
       dist: trusty
-    - elixir: 1.5.0
-      otp_release: 19.1
-      dist: trusty
-    - elixir: 1.5.3
-      otp_release: 20.2
-      dist: trusty
-    - elixir: 1.6.0
-      otp_release: 20.2
-      dist: trusty
-    - elixir: 1.6.4
-      otp_release: 20.2
-      dist: trusty
-    - elixir: 1.6.5
-      otp_release: 21.0
-      dist: trusty
-    - elixir: 1.7.0
-      otp_release: 21.0
-      dist: trusty
-    - elixir: 1.7.1
-      otp_release: 21.0
-      dist: trusty
-    - elixir: 1.7.2
-      otp_release: 21.0
+    - elixir: 1.18.4-otp-28
+      otp_release: 28.1
       dist: trusty

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/curtail.ex
+++ b/lib/curtail.ex
@@ -87,7 +87,7 @@ defmodule Curtail do
     acc |> apply_omission(opts.omission) |> finalize_output(tags, opts)
   end
 
-  defp do_truncate([token | rest], tags, opts, chars_remaining, acc) do
+  defp do_truncate([token | rest], %Html{} = tags, opts, chars_remaining, acc) do
     acc = cond do
       Html.tag?(token) || Html.comment?(token) ->
         [token | acc]

--- a/lib/curtail/options.ex
+++ b/lib/curtail/options.ex
@@ -4,17 +4,20 @@ defmodule Curtail.Options do
 
   defstruct length: 100,
             omission: "...",
-            word_boundary: @default_word_boundary,
+            word_boundary: nil,
             break_token: nil
 
   alias __MODULE__
+
+  def default_word_boundary, do: @default_word_boundary
 
   def new(opts\\ []) do
     configure(struct(Options, opts))
   end
 
-  defp configure(opts = %Options{ word_boundary: true}) do
+  defp configure(opts = %Options{ word_boundary: boundary}) when boundary in [true, nil] do
     %Options{opts | word_boundary: @default_word_boundary}
   end
+
   defp configure(opts), do: opts
 end

--- a/test/curtail/options_test.exs
+++ b/test/curtail/options_test.exs
@@ -4,11 +4,15 @@ defmodule Curtail.OptionsTest do
   alias Curtail.Options
 
   test "creating options" do
-    assert Options.new == %Options{}
+    options = Options.new
+    assert %Regex{source: "\\S"} = options.word_boundary
+    assert options.omission == "..."
+    assert options.length == 100
+    assert options.break_token == nil
   end
 
   test "uses default word_boundary when word_boundary is `true`" do
-    assert Options.new([word_boundary: true]).word_boundary == ~r/\S/
+    assert %Regex{source: "\\S"} = Options.new([word_boundary: true]).word_boundary
   end
 
   test "overriding default options" do


### PR DESCRIPTION
After updating my project to Elixir 1.19.0, `curtail` failed to compile with:

```txt
== Compilation error in file lib/curtail/options.ex ==
** (ArgumentError) invalid default value for struct field word_boundary, Regex defines custom escaping rules which are not supported in struct defaults. The supported values are: lists, tuples, maps, atoms, numbers, bitstrings, PIDs and remote functions in the format &Mod.fun/arity
```

This PR addresses the above error, and it eliminates the compiler warnings:

```
    warning: use Mix.Config is deprecated. Use the Config module instead
    │
  3 │ use Mix.Config
    │ ~~~~~~~~~~~~~~
    │
    └─ config/config.exs:3
...

==> curtail
Compiling 1 file (.ex)
     warning: a struct for Curtail.Html is expected on struct update:

         %Curtail.Html{tags | open_tags: [token | tags.open_tags]}

     but got type:

         dynamic()

     where "tags" was given the type:

         # type: dynamic()
         # from: lib/curtail.ex:90:36
         tags

     when defining the variable "tags", you must also pattern match on "%Curtail.Html{}".

     hint: given pattern matching is enough to catch typing errors, you may optionally convert the struct update into a map update. For example, instead of:

         user = some_function()
         %User{user | name: "John Doe"}

     it is enough to write:

         %User{} = user = some_function()
         %{user | name: "John Doe"}

     typing violation found at:
     │
 107 │         %Html{tags | open_tags: [token | tags.open_tags]}
     │         ~
     │
     └─ (curtail 2.0.0) lib/curtail.ex:107:9: Curtail.do_truncate/5
```